### PR TITLE
Fix error in case of special $EDITOR env var

### DIFF
--- a/nb
+++ b/nb
@@ -1509,7 +1509,7 @@ Can't edit archives. Export archive and expand to edit.\\n"
   then
     cd "${_file_path}" && "${_editor_command[@]}"
   else
-    "${_editor_command[@]}" "${_file_path}"
+    eval "${_editor_command[@]}" "${_file_path}"
   fi
 }
 


### PR DESCRIPTION
My $EDITOR is set to `vim -u <my-vimrc>`.

Without `eval`,` "${_editor_command[@]}" "${_file_path}"` would throw and error when running `nb edit`, 
and adding `eval` in front of the line fixes this issue.