### PR TITLE
Enable to use odd filenames

### DIFF
--- a/nb
+++ b/nb
@@ -5720,7 +5720,8 @@ _index() {
         # grep -n "^${1:-}$" "${2:-}" | cut -f1 -d:
         # awk 'match($0,v){print NR; exit}' v="^${1:-}$" "${2:-}"
         # rg --color=never --line-number "^${1:-}$" "${2:-}" | cut -d: -f1
-        sed -n "/^${1:-}$/=" "${2:-}"
+        escaped=$(printf "%s" "${1:-}" | sed -e 's/[\[\*]/\\&/g')
+        sed -n "/^$escaped$/=" "${2:-}"
       }
 
       local _basename="${2:-}"
@@ -6428,7 +6429,8 @@ HEREDOC
           local _item_identifier=
           # use `sed` directly instead of `_index get_id` for performance
           _item_identifier="$(
-            sed -n "/^${__basename:-}$/=" "${_notebook_path:-}/.index"
+            escaped=$(printf "%s" "${__basename:-}" | sed -e 's/[\[\*]/\\&/g')
+            sed -n "/^$escaped$/=" "${_notebook_path:-}/.index"
           )"
 
           local _max_identifier="${_max_id}"

--- a/nb
+++ b/nb
@@ -1240,7 +1240,8 @@ Can't edit archives. Export archive and expand to edit.\\n"
       touch "${_file_path:-}"
     fi
 
-    eval "${_editor_command} \"${_file_path}\""
+    escaped=${_file_path//$/\\$}
+    eval "${_editor_command} \"$escaped\""
   fi
 }
 


### PR DESCRIPTION
1. 75ce5c5 Fix errors in creating notes including `$` in filenames.

   ```sh
   # master build
   > nb create --filename 'foo$bar$.md'
   /usr/local/bin/nb: line 1263: bar: unbound variable
   ```

2. eabc1b1 Enable to get IDs even when filenames have `[` `*` chars.

   ```sh
   > nb add --filename '[foo].md'
   > nb add --filename '*foo*.md'

   # master build
   > nb list
   # prints no line

   # this PR
   > ./nb list
   [2] *foo*
   [1] [foo]
   ```