### PR TITLE
Cache all entries to calculate index

### DIFF
--- a/nb
+++ b/nb
@@ -6281,6 +6281,16 @@ HEREDOC
       local _max_id
       _max_id="$(_index get_max_id)"
 
+      if ! ((_no_id))
+      then
+        declare -A _index_map
+        __i=0
+        while IFS= read -r line; do
+          __i=$((++__i))
+          _index_map[$line]=$__i
+        done < "${_notebook_path:-}/.index"
+      fi
+
       for __basename in "${_filenames[@]:-}"
       do
         local _first_line=
@@ -6426,12 +6436,7 @@ HEREDOC
           _info_line="${_item_info}"
           _info_line_color="${_item_info}"
         else
-          local _item_identifier=
-          # use `sed` directly instead of `_index get_id` for performance
-          _item_identifier="$(
-            sed -n "/^${__basename:-}$/=" "${_notebook_path:-}/.index"
-          )"
-
+          local _item_identifier=${_index_map[${__basename:-}]}
           local _max_identifier="${_max_id}"
 
           if [[ -n "${_maybe_scope:-}" ]]


### PR DESCRIPTION
I'm not sure that this is a good way...

The current build reads `.index` and calculates the ID in showing each entry. This diff enables to cache all entries formerly and search them pretty fast.

This effects most significantly, it improves 49s → 10s to `nb list` on my box.

<details><summary><code>nb list</code>result</summary>

```sh
> time ./nb list

________________________________________________________
Executed in   49.56 secs   fish           external
   usr time   20.24 secs  149.00 micros   20.24 secs
   sys time   27.77 secs  814.00 micros   27.77 secs


> time ./nb list > /dev/null

________________________________________________________
Executed in   10.92 secs   fish           external
   usr time    6.19 secs  132.00 micros    6.19 secs
   sys time    4.91 secs  884.00 micros    4.91 secs
```
</details>