### PR TITLE
Remove CR in the last of titles

### DIFF
--- a/nb
+++ b/nb
@@ -1762,10 +1762,10 @@ _get_content() {
 
     if [[ -n "${_title:-}"        ]]
     then
-      printf "%s\\n" "${_title}"
+      printf "%s\\n" "${_title/%$'\r'}"
     elif [[ -n "${_first_line:-}" ]]
     then
-      printf "%s\\n" "__first_line:${_first_line}"
+      printf "%s\\n" "__first_line:${_first_line/%$'\r'}"
     fi
 
   fi


### PR DESCRIPTION
I noticed some imported notes have the CR+LF format. Then `nb list` shows redundant `\r` and broken display. This patch removes it.

```sh
# create a DOS format file. For example, Vim can make such a file with
# `set fileformat=dos` option.
> nb add

> nb show -p test:3
* foo
bar

# show `"` at the left due to `\r` in the file.
> nb ls
"test:3] 20201024231041.md · "* foo
[test:]  *foo*
[test:]  [foo]
```
