### PR TITLE
Add support for XDG-base-directories compliant NB_HIST variable 

### DIFF
--- a/nb
+++ b/nb
@@ -10319,7 +10319,7 @@ Example:
   $
 HEREDOC
 _shell() {
-  HISTFILE="${HOME}/.${_ME}_history"
+  HISTFILE="${NB_HIST:-${HOME}/.${_ME}_history}"
   set -o history
 
   local _initial_command=


### PR DESCRIPTION
Analogous of `NB_DIR` which is already implemented, but for the history file.
For example, I have `export NB_HIST="${XDG_DATA_HOME:-$HOME/.local/share}/nb_history"` in my `.profile`.

Does not break backwards compatibility for those who already have a ~/.nb_history file.