### PR TITLE
Support includes in git config

### DIFF
--- a/nb
+++ b/nb
@@ -2782,10 +2782,10 @@ HEREDOC
     fi
 
     local _git_name=
-    _git_name="$(git config --global user.name || printf '')"
+    _git_name="$(git config --global --includes user.name || printf '')"
 
     local _git_email=
-    _git_email="$(git config --global user.email || printf '')"
+    _git_email="$(git config --global --includes user.email || printf '')"
 
     if [[ -z "${_git_name:-}"   ]] ||
        [[ -z "${_git_email:-}"  ]]


### PR DESCRIPTION
`nb` checks for the git configuration of user name and user email.
Before this commit, `nb` would use `git config --global`, which does
not follow included files from `~/.gitconfig`, because `--global` is
specified. See [git-config] for more details.

`nb` now reads the configuration from an included file, instead of
prompting for missing configuration and force-setting it in
`~/.gitconfig` directly.

I did not find any tests related to `_git_required`, so I didn't
add/update any tests. I tested it locally and it works as desired.

Further elaboration below:

If you have a `~/.gitconfig` file with an include, e.g. for a user
email:
```ini
[include]
  path = ~/.gitconfigemail
```

Where that file includes:
```ini
[user]
  email = name@example.com
```

The output of the git config with and without `--includes` is:
```shell
$ git config --global user.email

$ git config --global --includes user.email
name@example.com

$
```

Fixes #86

[git-config]: https://git-scm.com/docs/git-config#Documentation/git-config.txt---no-includes