### PR TITLE
✨ Support PAGER properly

### DIFF
--- a/nb
+++ b/nb
@@ -2227,12 +2227,15 @@ _pager() {
   if [[ -n "${PAGER:-}" ]] && [[ "${PAGER:-}" =~ less ]]
   then
     "${PAGER}" -R --CLEAR-SCREEN --prompt="$(_less_prompt)"
+  elif [[ -n "${PAGER:-}" ]]
+  then
+      "${PAGER}"
+  elif _command_exists "bat"
+  then
+      bat --style numbers,grid
   elif _command_exists "less"
   then
     less -R --CLEAR-SCREEN --prompt="$(_less_prompt)"
-  elif [[ -n "${PAGER:-}" ]]
-  then
-    "${PAGER}"
   else
     cat
   fi


### PR DESCRIPTION
Problem: If `PAGER` is set, but `less` is installed, `less` is used.

`nb` should respect the `PAGER` environment variable over `less`.

Additionally, if `bat` is available, it should be preferred over `less`.