### PR TITLE
Make ncat listen on the NB_SERVER_HOST hostname

### DIFF
--- a/nb
+++ b/nb
@@ -19454,11 +19454,11 @@ HEREDOC
   # Description:
   #   Start the HTTP server in the background.
   _browse_serve() {
-    (ncat                                   \
-      --exec "${_MY_PATH} browse --respond" \
-      --keep-open                           \
-      --listen                              \
-      --source-port "${NB_SERVER_PORT}"     \
+    (ncat                                     \
+      --exec "${_MY_PATH} browse --respond"   \
+      --keep-open                             \
+      --listen                                \
+      "${NB_SERVER_HOST}" "${NB_SERVER_PORT}" \
       2>/dev/null) &
 
     local _pid="${!}"


### PR DESCRIPTION
From ncat's manual:

> "If hostname is omitted, it defaults to listening on all available addresses
> over IPv4 and IPv6."

In most cases that leaves the port open to all devices on the local network so
the data can be viewed and edited by anyone. Using localhost (NB_SERVER_HOST's
default value) as hostname will make ncat listen only on the loopback
interface, so the data will be accessible only from localhost.

Also, from what I've gathered, "--source-port" is supposed to be used in
"connect mode", not in "listen mode".

Before the change "nb browse" was listening on all available addresses over IPv4 and IPv6:

```bash
$ ss -tlnp "sport :6789"
State  | Recv-Q | Send-Q | Local Address:Port | Peer Address:Port | Process
LISTEN | 0      | 10     | 0.0.0.0:6789       | 0.0.0.0:*         | users:(("ncat",pid = 393740,fd = 4))
LISTEN | 0      | 10     | [::]:6789          | [::]:*            | users:(("ncat",pid = 393740,fd = 3))
```


After the change "nb browse" is listening on [::1] (localhost in IPv6):

```bash
$ ss -tlnp "sport :6789"
State  | Recv-Q | Send-Q | Local      Address:Port |      Peer Address:Port | Process
LISTEN | 0      | 10     | [::1]:6789 |            [::]:* |    users:(("ncat",pid=395077,fd=3))
```