### PR TITLE
nb: migrate to homebrew/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,12 @@ Also supported for various enhancements:
 #### macOS / Homebrew
 
 ```bash
-brew tap xwmx/taps
 brew install nb
 ```
 
 Installing `nb` with Homebrew also installs
 the recommended dependencies above
-and completion scripts for Bash and Zsh.
+and completion scripts for Bash, Zsh, and Fish.
 
 #### Ubuntu, Windows WSL, and others
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -215,13 +215,12 @@ Also supported for various enhancements:
 #### macOS / Homebrew
 
 ```bash
-brew tap xwmx/taps
 brew install nb
 ```
 
 Installing `nb` with Homebrew also installs
 the recommended dependencies above
-and completion scripts for Bash and Zsh.
+and completion scripts for Bash, Zsh, and Fish.
 
 #### Ubuntu, Windows WSL, and others
 

--- a/etc/README.md
+++ b/etc/README.md
@@ -2,7 +2,7 @@
 
 ## Homebrew
 
-Installing via Homebrew with `brew install xwmx/taps/nb` will also
+Installing via Homebrew with `brew install nb` will also
 install the completion scripts.
 
 A one-time setup might be needed to [enable completion for all Homebrew

--- a/nb
+++ b/nb
@@ -24666,7 +24666,7 @@ HEREDOC
   then
     cat <<HEREDOC
 Installed with Homebrew. To update, run:
-  brew upgrade xwmx/taps/nb
+  brew upgrade nb
 HEREDOC
   else
     local _nb_url="${_REPO_RAW_URL}/nb"


### PR DESCRIPTION
Due to the successful merge of https://github.com/Homebrew/homebrew-core/pull/103458, `nb` is now a part of `homebrew/core` and can be installed without using a tap by running:

```shell
brew install nb
```

This PR updates all references to `xwmx/taps/nb` to instead point to `nb` (in `homebrew/core`).

**See also https://github.com/xwmx/homebrew-taps/pull/1, which migrates the `xwmx/taps/nb` formula to `homebrew/core`.**