### PR TITLE
fix(bookmark-help): use same less options in bookmark as in nb

### DIFF
--- a/bin/bookmark
+++ b/bin/bookmark
@@ -112,7 +112,7 @@ HEREDOC
           "${PAGER}"
         elif hash "less" 2>/dev/null
         then
-          less              \
+          less -R           \
             --CLEAR-SCREEN  \
             --prompt="> scroll for more, h for help, or q to quit"
         else


### PR DESCRIPTION
The `less` command used to display the usage text in `bookmark` is missing the `-R` option to correctly display escape sequences:

<details>

<summary>
To reproduce, use <pre>bookmark -h</pre>
</summary>

![image](https://user-images.githubusercontent.com/24478021/188213193-7cdac529-408c-4029-ba6c-e7bd9ca7e001.png)

</details>