### PR TITLE
Fix for #202 when running [nb init; nb todo add abc --task xyz; nb tasks todo]

### DIFF
--- a/nb
+++ b/nb
@@ -24989,8 +24989,8 @@ _todo() {
 
           {
             grep --color=never          \
-              -e "\- \[[[:space:]]*\] " \
-              -e "\- \[x\] "            \
+              -e "- \[[[:space:]]*\] " \
+              -e "- \[x\] "            \
               "${__item_path:-}" || :
           } | {
             local _counter=0


### PR DESCRIPTION
Please check to see if the change makes sense. Not that comfortable with grep.

To reproduce:
- Install nb (using wget/curl)
- `nb todo add abc --task xyz`
- `nb tasks todo`

```bash
[1] ✔️  [ ] abc
--------------
grep: warning: stray \ before -
grep: warning: stray \ before -
[1 1] [ ] xyz
```