### PR TITLE
Don't markup checkboxes in (/after) <textarea>.

### DIFF
--- a/nb
+++ b/nb
@@ -11523,9 +11523,9 @@ HEREDOC
     local _checkbox_pattern_close="<\/span><span class=\"muted\">\]<\/span>"
 
     LC_ALL=C sed -E                                                               \
-      -e "s/\[x\]/${_checkbox_pattern_open}x${_checkbox_pattern_close}/g"         \
-      -e "s/\[ \]/${_checkbox_pattern_open}${_NBSP}${_checkbox_pattern_close}/g"  \
-      -e "s/\[\]/${_checkbox_pattern_open}${_NBSP}${_checkbox_pattern_close}/g"
+      -e "1, /\<textarea\>/ s/\[x\]/${_checkbox_pattern_open}x${_checkbox_pattern_close}/g"         \
+      -e "1, /\<textarea\>/ s/\[ \]/${_checkbox_pattern_open}${_NBSP}${_checkbox_pattern_close}/g"  \
+      -e "1, /\<textarea\>/ s/\[\]/${_checkbox_pattern_open}${_NBSP}${_checkbox_pattern_close}/g"
   }
 }
 


### PR DESCRIPTION
For nb browse (gui): This removes the extra <span> tags when editing an item with checkboxes. This leaves the checkbox annotations before the <textarea> tags. Will work as long as there is a max of one textarea per page.