### PR TITLE
check _use_pandoc before applying sed replacement.

### DIFF
--- a/nb
+++ b/nb
@@ -11517,14 +11517,20 @@ HEREDOC
   } | {
     LC_ALL=C sed -e "s/<a\ /<a\ rel=\"noopener\ noreferrer\"\ /g"
   } | {
-    # mark up checkboxes
-    local _checkbox_pattern_open="<span class=\"muted\">[<\/span><span class=\"identifier\">"
-    local _checkbox_pattern_close="<\/span><span class=\"muted\">\]<\/span>"
 
-    LC_ALL=C sed -E                                                                       \
+    if ((_use_pandoc))
+    then
+      # mark up checkboxes
+      local _checkbox_pattern_open="<span class=\"muted\">[<\/span><span class=\"identifier\">"
+      local _checkbox_pattern_close="<\/span><span class=\"muted\">\]<\/span>"
+
+      LC_ALL=C sed -E                                                                     \
 -e "1, /<textarea/ s/\[x\]/${_checkbox_pattern_open}x${_checkbox_pattern_close}/g"        \
 -e "1, /<textarea/ s/\[ \]/${_checkbox_pattern_open}${_NBSP}${_checkbox_pattern_close}/g" \
 -e "1, /<textarea/ s/\[\]/${_checkbox_pattern_open}${_NBSP}${_checkbox_pattern_close}/g"
+      else
+        cat
+      fi
   }
 }
 


### PR DESCRIPTION
Follow-up to  #209. [Related comment](https://github.com/xwmx/nb/issues/209#issuecomment-1290738960_)

Note: I'm not too familiar with ace and other contexts which nb browse supports. I tested with w3m and firefox with and without pandoc.