### PR TITLE
fix: Remove a subshell for KSH and ZSH entrypoints

### DIFF
--- a/nb.ksh/nb
+++ b/nb.ksh/nb
@@ -5,4 +5,4 @@ alias local="typeset"
 # no-op placeholder for Bash `shopt`.
 shopt() { :; }
 
-source "$(cd "$(dirname "${0}")"; pwd)/../nb"
+source "$(CDPATH= cd -- "${0%/*}"; pwd)/../nb"

--- a/nb.zsh/nb
+++ b/nb.zsh/nb
@@ -6,4 +6,4 @@ setopt KSH_ARRAYS
 # no-op placeholder for Bash `shopt`.
 shopt() { :; }
 
-source "$(cd "$(dirname "${0}")"; pwd)/../nb"
+source "$(CDPATH= cd -- "${0%/*}"; pwd)/../nb"


### PR DESCRIPTION
Improves the performance of the KSH and ZSH entrypoints by removing the overhead of a subshell .

This also adds `CDPATH=` and `--` for extra safety.