### PR TITLE
Fix shortcut documentation for todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2271,7 +2271,7 @@ See [`bookmark help`](#bookmark-help) for more information.
   </sup>
 </p>
 
-Use [`nb todo`](#todo) (shortcut: [`nb t`](#todo))
+Use [`nb todo`](#todo) (shortcut: [`nb to`](#todo))
 to create, list, and update todos.
 `nb` todos are [structured Markdown documents](#nb-markdown-todo-file-format)
 referencing a single primary todo,


### PR DESCRIPTION
The README incorrectly said that the shortcut is `t`, but that's for tasks.  The proper shortcut for todos is `to`.

I caught this because `nb t` was weirdly slow compared to `nb todo`, and then I realized part of the reason is it was catching tasks in my notes.