### PR TITLE
Add NB_SEARCH_UTILITY environment variable

### DIFF
--- a/nb
+++ b/nb
@@ -16631,7 +16631,7 @@ _search() {
     shift
   done
 
-  if [[ -z $_search_utility ]]; then
+  if [[ -z $_search_utility ]] && [[ -n $NB_SEARCH_UTILITY ]]; then
     _search_utility=$NB_SEARCH_UTILITY
   fi
 

--- a/nb
+++ b/nb
@@ -16631,6 +16631,10 @@ _search() {
     shift
   done
 
+  if [[ -z $_search_utility ]]; then
+    _search_utility=$NB_SEARCH_UTILITY
+  fi
+
   local _current_notebook_path=
   _current_notebook_path="$(_notebooks current --path)"
 


### PR DESCRIPTION
This pull request introduces a new environment variable, _NB_SEARCH_UTILITY_, into  the notebook search functionality. The changes are compact yet impactful, involving just 4 lines of additions with no deletions.

**Key Changes:**

- Added a check for an existing _search_utility variable.
- If _search_utility is not set, it now defaults to the value of the new _NB_SEARCH_UTILITY_ environment variable.

**Purpose:**
The introduction of _NB_SEARCH_UTILITY_ aims to enhance our notebook's search capabilities by allowing for dynamic utility configuration. This is particularly useful for environments where the search utility might differ or where a user prefers a custom search method.

**Benefits:**
- A user doesn't always have to recall to specify their favorite search tool using the `--tool` or `--utility` option
- Different search tools can be used browser as well when using `nb browse`. This was my primary motivation for this PR.

**Testing:**
The changes are minimal and straightforward, focusing solely on environment variable management. I've tested the following:

- The notebook search functions as expected when NB_SEARCH_UTILITY is set.
- The default behavior remains unaffected when NB_SEARCH_UTILITY is not set.


Looking forward to feedback and suggestions from the team!