### PR TITLE
Extend _GIT_ENABLED Support to Note/Todo Deletions in nb CLI

### DIFF
--- a/nb
+++ b/nb
@@ -14363,27 +14363,28 @@ _delete() {
     then
       _pin unpin "${_notebook_path}/${_relative_path}" &> /dev/null || :
 
-      if [[ -d "${_notebook_path}/${_relative_path}"            ]]  &&
+            if [[ -d "${_notebook_path}/${_relative_path}" ]] &&
          [[ -z "$(ls -A "${_notebook_path}/${_relative_path}")" ]]
       then
         rm -r "${_notebook_path:?}/${_relative_path:?}"
       else
-        if git -C "${_notebook_path:?}" check-ignore    \
-             "${_notebook_path:?}/${_relative_path:?}" 1>/dev/null
+        if [[ -z "${_GIT_ENABLED}" ]] && 
+           git -C "${_notebook_path:?}" check-ignore "${_notebook_path:?}/${_relative_path:?}" 1>/dev/null
         then
           rm -r "${_notebook_path:?}/${_relative_path:?}"
+        elif [[ -z "${_GIT_ENABLED}" ]]; then
+          git -C "${_notebook_path:?}" rm -r "${_notebook_path:?}/${_relative_path:?}" 1>/dev/null
         else
-          git -C "${_notebook_path:?}" rm -r            \
-            "${_notebook_path:?}/${_relative_path:?}" 1>/dev/null
+          rm -r "${_notebook_path:?}/${_relative_path:?}" 
         fi
       fi
-
-      if [[ ! -e "${_notebook_path}/${_relative_path}"  ]]
+      
+      if [[ ! -e "${_notebook_path}/${_relative_path}" ]]
       then
         _index delete "${_basename}" "${_folder_path}"
-
+      
         _git checkpoint "${_notebook_path}" "[${_ME}] Delete: ${_relative_path}"
-
+      
         printf "Deleted:  %s\\n" "${_info_line}"
       fi
     else


### PR DESCRIPTION
This pull request introduces an enhancement to the `nb` CLI's handling of note and todo deletions, specifically in the context of the `_GIT_ENABLED` environment variable. The `nb` CLI already incorporates the `_GIT_ENABLED` variable, which, when set to a non-empty string, disables the use of GIT for its operations. This change extends that functionality to the deletion process of notes and todos.

#### Key Changes:
- **Conditional Git Command Execution**: The script has been adjusted to conditionally execute git commands based on the `_GIT_ENABLED` variable. When this variable is set to an empty string, indicating GIT functionality is enabled, the script will execute git-specific commands. Conversely, if `_GIT_ENABLED` is not empty, these commands are bypassed.
  
- **Maintained Original Functionality**: Outside the scope of the `_GIT_ENABLED` variable, the original functionality of the script remains unchanged. This ensures that existing workflows are not disrupted by this update.

#### Impact:
This change enhances the `nb` CLI's flexibility and control in environments where GIT usage might be restricted or not preferred. It allows users to leverage the full capabilities of `nb` without relying on GIT, aligning with scenarios where a simpler or more streamlined workflow is desired.

#### Testing:
- **GIT-Enabled Environments**: Extensive testing in environments where `_GIT_ENABLED` is an empty string, to ensure that GIT commands execute as expected.
- **Non-GIT Environments**: Validation in scenarios where `_GIT_ENABLED` is set to a non-empty string, confirming that GIT commands are appropriately skipped.

This update is a step forward in making the `nb` CLI more adaptable to various user environments and preferences. Your review and feedback on this implementation are highly appreciated.
