### PR TITLE
update: minimal performance improvement when listing tags

### DIFF
--- a/nb
+++ b/nb
@@ -16981,14 +16981,12 @@ _search() {
     fi
 
     local _grep_arguments=(
-      "--extended-regexp"
+      "-P"
       "-I"
       "--ignore-case"
       "--only-matching"
-      -e '[[:space:]]#[A-Za-z0-9_-]+'
-      -e '^#[A-Za-z0-9_-]+'
+      -e '(^|\s)#[A-Za-z0-9_-]+'
     )
-
     {
       local __target_path=
       for   __target_path in "${_target_paths[@]:-}"


### PR DESCRIPTION
This is a very small performance improvement. Here are some measurements I took when running `nb --tags` on more than 1000 notes.

- Before: it took 122 seconds
- Now: it takes 101 seconds

I replaced `--extended-regexp` with `-P` and simplified the regular expression a bit.

---

One question: Why can't we use `--utility` when listing tags? That would improve performance significantly.