### PR TITLE
Fixed inconsistent type listings in the help documentation for the `-type` argument of the `search` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,7 +1147,7 @@ NB_LIMIT set to 3
 ```
 
 List [#tagged](#tagging) items by passing `\#escaped` or `"#quoted"` hashtags
-or tags specified with the [`--tags`](#ls) option. Multiple tags perform an 
+or tags specified with the [`--tags`](#ls) option. Multiple tags perform an
 `AND` query:
 
 ```bash
@@ -1698,7 +1698,7 @@ Items can be deleted within terminal and GUI web browsers using
 [4] example_file.md "Example Title"
 
               [delete]
- 
+
 ```
 
 For more information, see [Browsing](#-browsing).
@@ -3221,7 +3221,7 @@ to delete an item:
 [4] example_file.md "Example Title"
 
               [delete]
- 
+
 ```
 
 #### `browse` Search
@@ -4983,7 +4983,7 @@ to download the original file:
 ❯nb · home : 123 · ↓ | +
 
     example.pdf
- 
+
 ```
 
 ### ⚙️ `set` & `settings`
@@ -7832,8 +7832,8 @@ Options:
   -t, --tags                    List all tags found in the notebook.
   --type <type>, --<type>       Search items of <type>. <type> can be a file
                                 extension or one of the following types:
-                                note, bookmark, document, archive, image,
-                                video, audio, folder, text
+                                archive, audio, book, bookmark, document,
+                                folder, image, note, text, video
   --utility <name>              The name of the search utility to search with.
 
 Description:

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -1153,7 +1153,7 @@ NB_LIMIT set to 3
 ```
 
 List [#tagged](#tagging) items by passing `\#escaped` or `"#quoted"` hashtags
-or tags specified with the [`--tags`](#ls) option. Multiple tags perform an 
+or tags specified with the [`--tags`](#ls) option. Multiple tags perform an
 `AND` query:
 
 ```bash
@@ -1704,7 +1704,7 @@ Items can be deleted within terminal and GUI web browsers using
 [4] example_file.md "Example Title"
 
               [delete]
- 
+
 ```
 
 For more information, see [Browsing](#-browsing).
@@ -3227,7 +3227,7 @@ to delete an item:
 [4] example_file.md "Example Title"
 
               [delete]
- 
+
 ```
 
 #### `browse` Search
@@ -4989,7 +4989,7 @@ to download the original file:
 ❯nb · home : 123 · ↓ | +
 
     example.pdf
- 
+
 ```
 
 ### ⚙️ `set` & `settings`
@@ -7838,8 +7838,8 @@ Options:
   -t, --tags                    List all tags found in the notebook.
   --type <type>, --<type>       Search items of <type>. <type> can be a file
                                 extension or one of the following types:
-                                note, bookmark, document, archive, image,
-                                video, audio, folder, text
+                                archive, audio, book, bookmark, document,
+                                folder, image, note, text, video
   --utility <name>              The name of the search utility to search with.
 
 Description:

--- a/nb
+++ b/nb
@@ -16707,8 +16707,8 @@ $(_color_primary "Options"):
   -t, --tags                    List all tags found in the notebook.
   --type <type>, --<type>       Search items of <type>. <type> can be a file
                                 extension or one of the following types:
-                                note, bookmark, document, archive, image,
-                                video, audio, folder, text
+                                archive, audio, book, bookmark, document,
+                                folder, image, note, text, video
   --utility <name>              The name of the search utility to search with.
 
 $(_color_primary "Description"):


### PR DESCRIPTION
In the help output for `list` and `ls` commands, the file type list was displayed as:
```
archive, audio, book, bookmark, document,
folder, image, note, text, video
```

The `search` command previously had this order:
```
note, bookmark, document, archive, image,
video, audio, folder, text
```

Fixed the `search` command output to maintain consistent type ordering with `list` and `ls`.