### PR TITLE
Remove --term-hmargin=1 lowdown option

### DIFF
--- a/nb
+++ b/nb
@@ -19234,7 +19234,6 @@ Can't show archives. Export archive and expand to edit.\\n"
                 lowdown                         \
                   -Tterm                        \
                   --term-columns="${_COLUMNS}"  \
-                  --term-hmargin=1              \
                   --term-width="${_COLUMNS}"    \
                   | _pager
                 ;;


### PR DESCRIPTION
With this option horizontal lines get wrapped
![2025-04-21_14:54:05](https://github.com/user-attachments/assets/6cf7b71e-7cf1-4bc0-b6ed-82912189a557)
![2025-04-21_14:54:53](https://github.com/user-attachments/assets/b6eb7a39-1cd3-47c1-8ae7-686c9195a911)
