### PR TITLE
Use XDG_CONFIG_HOME if available

### DIFF
--- a/nb
+++ b/nb
@@ -440,8 +440,15 @@ _option_value_is_present() {
 #
 # Default: `$HOME/.nbrc`
 #
-# The location of the .nbrc configuration file.
-export NBRC_PATH="${NBRC_PATH:-"${HOME}/.${_ME}rc"}"
+# Check if XDG_CONFIG_HOME exists
+if [[ -n "${XDG_CONFIG_HOME}" ]]; then
+  # If XDG_CONFIG_HOME exists put .nbrc config file in a subdirectory.
+  mkdir -p "${XDG_CONFIG_HOME}/${_ME}" &&
+  export NBRC_PATH="${NBRC_PATH:-"${XDG_CONFIG_HOME}/${_ME}/.${_ME}rc"}"
+else
+  # Otherwise, use the default path
+  export NBRC_PATH="${NBRC_PATH:-"${HOME}/.${_ME}rc"}"
+fi
 
 # Handle symlinked NBRC_PATH.
 if [[ -L "${NBRC_PATH}" ]]


### PR DESCRIPTION
Be warned. This is my first pull request **_EVAR_**. I'm not much of a coder, and I don't write my own bash scripts. I've tested this and it seeeems to work as a clean install, but I doubt it'll handle existing installs elegantly, if at all. Also this script is huuuge so I could've easily overlooked another place that needs an edit. If I've not gone about this the correct way, lemme know I'll try my best to do better next time. 

This change should check if XDG_CONFIG_HOME exists, and if it does, create an nb subdirectoy in there for your .nbrc file (by way of the _ME variable)

I find having .nbrc in my home directory icky and want to tuck it away where it belongs. If this works, I'll try making XDG_STATE_HOME the default parent of the default notebook directory next. 

This doesn't handle anything fancy like the preference-ordered XDG_CONFIG_DIRS variable.

