### PR TITLE
Grammar/wording update in help text for auto_sync setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8059,9 +8059,11 @@ Alias:
 ```text
 [1]  auto_sync
      ---------
-     By default, operations that trigger a git commit like `add`, `edit`,
-     and `delete` will sync notebook changes to the remote repository, if
-     one is set. To disable this behavior, set this to "0".
+    If set to "1", operations like `add`, `edit`, and `delete`
+    will trigger a git commit that syncs notebook changes to
+    the remote repository.
+
+    To disable this behavior, set this value to "0".
 
      • Default Value: 1
 ```

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -8065,9 +8065,11 @@ Alias:
 ```text
 [1]  auto_sync
      ---------
-     By default, operations that trigger a git commit like `add`, `edit`,
-     and `delete` will sync notebook changes to the remote repository, if
-     one is set. To disable this behavior, set this to "0".
+    If set to "1", operations like `add`, `edit`, and `delete`
+    will trigger a git commit that syncs notebook changes to
+    the remote repository.
+
+    To disable this behavior, set this value to "0".
 
      • Default Value: 1
 ```


### PR DESCRIPTION
Just a small PR to fix some grammar in the help-text.

Specifically, the sentence

> By default, operations that trigger a git commit like `add`, `edit`, and `delete` will sync notebook changes to the remote repository, if one is set.

does not scan well. It has been changed to:

> If set to "1", operations like `add`, `edit`, and `delete` will trigger a git commit that syncs notebook changes to the remote repository.

This includes changing the word "one" to the numeral "1" so that it a) matches the later instruction that references the numeral "0", and b) matches the actual input required from the user when using the `nb set auto_sync` command.

Thanks!