### PR TITLE
fix: handle git submodule notebooks with symlinked .git files

### DIFF
--- a/nb
+++ b/nb
@@ -8969,7 +8969,8 @@ HEREDOC
            [[ -n "${_local_notebook_path:-}"        ]]
         then
           _notebook_path="${_local_notebook_path%/}"
-        elif [[ -d "${NB_DIR}/${_selector_notebook:-}/.git"    ]] &&
+        elif [[ -d "${NB_DIR}/${_selector_notebook:-}/.git"    ]] ||
+             [[ -e "${NB_DIR}/${_selector_notebook:-}/.git"    ]] &&
              [[ -f "${NB_DIR}/${_selector_notebook:-}/.index"  ]]
         then
           _notebook_path="${NB_DIR}/${_selector_notebook%/}"


### PR DESCRIPTION
Previously, notebooks that were git submodules would fail with 'Notebook not found' errors because the .git file in submodules is a symlink (text file pointing to the actual .git directory), not a directory. The condition only checked `-d` (directory) but not `-e` (exists).

This change adds `[[ -e ... ]]` check to properly detect both git directories and git submodule symlink files, allowing submodule-based notebooks to work correctly.