### PR TITLE
fix: README.md missing '/' on bash instruction

### DIFF
--- a/etc/README.md
+++ b/etc/README.md
@@ -74,7 +74,7 @@ be available.
 Place the completion script in `/etc/bash_completion.d/`:
 
 ```bash
-sudo curl -L https://raw.githubusercontent.com/xwmx/nb/master/etc/nb-completion.bash -o etc/bash_completion.d/nb
+sudo curl -L https://raw.githubusercontent.com/xwmx/nb/master/etc/nb-completion.bash -o /etc/bash_completion.d/nb
 ```
 
 #### macOS


### PR DESCRIPTION
The manual bash instruction on README.md is missing a `/` on the `etc` path.
```bash
> sudo curl -L https://raw.githubusercontent.com/xwmx/nb/master/etc/nb-completion.bash -o etc/bash_completion.d/nb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file etc/bash_completion.d/nb: No such file or directory
  0  4125    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (23) client returned ERROR on write of 831 bytes
```